### PR TITLE
Bugfix: Secret password sanitization & added input validation

### DIFF
--- a/backend/app/crud/secret.py
+++ b/backend/app/crud/secret.py
@@ -40,7 +40,7 @@ def create_secret(db: Session, owner_id: int, secret: SecretCreate) -> models.Se
         remaining_accesses=secret.max_accesses,
         expires_at=expires_at,
         is_revoked=False,
-        password_hash=secret.password
+        password_hash=(secret.password.strip() or None) if secret.password else None
     )
     db.add(db_secret)
     db.commit()

--- a/backend/app/schemas/secret.py
+++ b/backend/app/schemas/secret.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 from datetime import datetime
 from typing import Optional
 
@@ -10,6 +10,21 @@ class SecretCreate(BaseModel):
     expires_in_seconds: int  # How many seconds until the secret expires (e.g., 3600 for 1 hour)
     password: Optional[str] = None  # Optional password to protect access to this secret
 
+    @field_validator('expires_in_seconds')
+    @classmethod
+    def validate_expiration(cls, v: int):
+        if v is None or v == 0:
+            raise ValueError('Expiration time is required.')
+        elif v <= 0:
+            raise ValueError('Expiration time must be greater than 0.')
+        return v
+
+    @field_validator('max_accesses')
+    @classmethod
+    def validate_accesses(cls, v: int):
+        if v <= 0:
+            raise ValueError('Max allowed accesses must be at least 1.')
+        return v
 
 class SecretResponse(BaseModel):
     """Schema for returning created secret (includes the token for sharing)"""

--- a/mobile/leakcheck/app/home/secrets.tsx
+++ b/mobile/leakcheck/app/home/secrets.tsx
@@ -58,7 +58,16 @@ export default function SecretsScreen() {
 
       if (!response.ok) {
         const error = await response.json();
-        setErrorMessage(`Error ${response.status}: ${error.detail}`);
+
+        if (Array.isArray(error.detail)) {
+            const messages = error.detail.map((err: any) =>
+                err.msg.replace('Value error, ', '')
+            );
+            setErrorMessage(messages.join('\n'));
+        } else {
+            setErrorMessage(`Error ${response.status}: ${error.detail}`);
+        }
+
         setGettingLink(false);
         return;
       }


### PR DESCRIPTION
**Changes:**
- **Backend**
  - Updated create_secret to properly sanitize password inputs _- bugfix_
  - Added Pydantic validators in SecretCreate to ensure:
    - expires_in_seconds is greater than 0
    - max_accesses is at least 1
- **Mobile**
  - Updated getSecretLink to handle Pydantic's array-based error responses